### PR TITLE
Removing tail -r and replacing with a smarter awk

### DIFF
--- a/git-scp
+++ b/git-scp
@@ -65,7 +65,7 @@ if [ $head_option = 'status' ]
     then
         changes=$(git status --porcelain 2>&1)
     else
-        changes=$(git log $head_option..HEAD --name-status --pretty="format:" --abbrev-commit | tail -r | awk '!x[$0]++' 2>&1)
+        changes=$(git log $head_option..HEAD --name-status --pretty="format:" --abbrev-commit | awk '!x[$2]++' 2>&1)
 fi
 
 


### PR DESCRIPTION
This should fix the file sync order by removing duplicate file names so that only the first file name that appears is put into our list of operations. 

```
$  git log HEAD~4..HEAD --name-status --pretty="format:" --abbrev-commit
M       test.txt

A       test.txt

D       test.txt

A       test.txt
```

In this example we would only want to know that text.txt has the modified flag, by apply our awk to the statement:

```
$  git log HEAD~4..HEAD --name-status --pretty="format:" --abbrev-commit | awk '!x[$2]++'
M       test.txt
```

We get the first occurrence only and our program will upload a new copy of this file without changing to much of the internals.
